### PR TITLE
Fix Markdown copy script

### DIFF
--- a/src/util/getContents.js
+++ b/src/util/getContents.js
@@ -1,7 +1,7 @@
 module.exports = function () {
     // Get parent chat container
     const chatContainer = document.querySelector(
-        "div.flex-1.flex.flex-col.gap-3.px-4.pt-16"
+        "div.flex-1.flex.flex-col.gap-3.px-4.pt-1"
     );
 
     // Get chat title (if exists)


### PR DESCRIPTION
Fixes #6 

- [x] fix `TypeError: e is null`
- [ ] fix empty content of `_Prompt:_` and `_Claude:_`